### PR TITLE
Add minimal 404 page

### DIFF
--- a/themes/arranstheme/layouts/404.html
+++ b/themes/arranstheme/layouts/404.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Page Not Found</title>
+</head>
+<body>
+    <h1>404 - Page Not Found</h1>
+    <p>Sorry, the page you are looking for does not exist.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a simple 404 page to arranstheme

## Testing
- `hugo version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e5bf7a700832f80c2a5f26340a1a9