### PR TITLE
Add basic footer, meta tags and 404 page

### DIFF
--- a/themes/arranstheme/layouts/404.html
+++ b/themes/arranstheme/layouts/404.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>{{ .Site.Title }} - Page Not Found</title>
+</head>
+<body>
+  <h1>404 - Page Not Found</h1>
+  <p>Sorry, the page you were looking for does not exist.</p>
+  <p><a href="{{ "/" | relURL }}">Return to the homepage</a></p>
+</body>
+</html>

--- a/themes/arranstheme/layouts/partials/footer.html
+++ b/themes/arranstheme/layouts/partials/footer.html
@@ -1,0 +1,3 @@
+<footer>
+  <p>&copy; {{ now.Format "2006" }} {{ .Site.Title }}</p>
+</footer>

--- a/themes/arranstheme/layouts/partials/meta.html
+++ b/themes/arranstheme/layouts/partials/meta.html
@@ -1,0 +1,6 @@
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="description" content="{{ with .Description }}{{ . }}{{ else }}{{ .Site.Title }}{{ end }}">
+<meta name="author" content="{{ with .Site.Params.author }}{{ . }}{{ else }}{{ .Site.Title }}{{ end }}">
+<meta property="og:title" content="{{ .Title }}" />
+<meta property="og:url" content="{{ .Permalink }}" />
+<meta property="og:description" content="{{ with .Description }}{{ . }}{{ else }}{{ .Site.Title }}{{ end }}" />


### PR DESCRIPTION
## Summary
- add a basic footer partial
- populate meta partial with common tags
- create a minimal 404 page

## Testing
- `hugo`

------
https://chatgpt.com/codex/tasks/task_e_684e5be84020832fb76e2a39e352f3ed