### PR TITLE
Add Hugo build check and cache

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -22,8 +22,16 @@ jobs:
         with:
           hugo-version: '0.88.1'
 
+      - name: Cache Hugo resources
+        uses: actions/cache@v3
+        with:
+          path: resources
+          key: ${{ runner.os }}-hugoresources-${{ hashFiles('**/config.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-hugoresources-
+
       - name: Build
-        run: hugo --minify
+        run: hugo --gc --minify
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
## Summary
- run `hugo --gc --minify` during build
- cache `resources` directory to speed up Hugo builds

## Testing
- `hugo --gc --minify`

------
https://chatgpt.com/codex/tasks/task_e_684e5c06e624832fbc14e3bb5b9603af