### PR TITLE
Update CI runner

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /public/
 /.idea
 *.iml
+.hugo_build.lock


### PR DESCRIPTION
## Summary
- update CI runner to Ubuntu 22.04 in GH Actions
- ignore `hugo` build lock file

## Testing
- `hugo --gc --minify`

------
https://chatgpt.com/codex/tasks/task_e_6854ddaad184832fb8fdf9317286602e